### PR TITLE
feat: OptionBlockSettingView에 대한 Core Data 연동

### DIFF
--- a/GitSetKit/Data/PersistenceController.swift
+++ b/GitSetKit/Data/PersistenceController.swift
@@ -113,12 +113,11 @@ extension PersistenceController {
 
 // MARK: Field CRUD
 extension PersistenceController {
-    func createField(name: String, type: Int16, order: Int16, typeBasedString: String? = nil, options: [Option]? = nil) -> Field {
+    func createField(name: String, type: Int16, typeBasedString: String? = nil, options: [Option]? = nil) -> Field {
         let newField = Field(context: container.viewContext)
         
         newField.name = name
         newField.type = type
-        newField.order = order
         if typeBasedString != nil {
             newField.typeBasedString = typeBasedString!
         }
@@ -143,7 +142,7 @@ extension PersistenceController {
         return results
     }
     
-    func updateField(field: Field, name: String? = nil, type: Int16? = nil, order: Int16? = nil, typeBasedString: String? = nil, options: [Option]? = nil) {
+    func updateField(field: Field, name: String? = nil, type: Int16? = nil, typeBasedString: String? = nil, options: [Option]? = nil) {
         var hasChanges: Bool = false
         
         if name != nil {
@@ -152,10 +151,6 @@ extension PersistenceController {
         }
         if type != nil {
             field.type = type!
-            hasChanges = true
-        }
-        if order != nil {
-            field.order = order!
             hasChanges = true
         }
         if typeBasedString != nil {
@@ -180,7 +175,7 @@ extension PersistenceController {
 
 // MARK: Option CRUD
 extension PersistenceController {
-    func createOption(value: String, shortDesc: String? = nil, detailDesc: String? = nil, order: Int16) -> Option {
+    func createOption(value: String, shortDesc: String? = nil, detailDesc: String? = nil) -> Option {
         let newOption = Option(context: container.viewContext)
         
         newOption.value = value
@@ -190,7 +185,6 @@ extension PersistenceController {
         if detailDesc != nil {
             newOption.detailDesc = detailDesc
         }
-        newOption.order = order
         
         return newOption
     }
@@ -210,7 +204,7 @@ extension PersistenceController {
     }
     
     func updateOption(option: Option, value: String? = nil, shortDesc: String? = nil
-                      , detailDesc: String? = nil, order: Int16? = nil) {
+                      , detailDesc: String? = nil) {
         var hasChanges: Bool = false
         
         if value != nil {
@@ -223,10 +217,6 @@ extension PersistenceController {
         }
         if detailDesc != nil {
             option.detailDesc = detailDesc!
-            hasChanges = true
-        }
-        if order != nil {
-            option.order = order!
             hasChanges = true
         }
         

--- a/GitSetKit/Field+CoreDataProperties.swift
+++ b/GitSetKit/Field+CoreDataProperties.swift
@@ -18,7 +18,6 @@ extension Field {
 
     @NSManaged public var name: String?
     @NSManaged public var type: Int16
-    @NSManaged public var order: Int16
     @NSManaged public var typeBasedString: String?
     @NSManaged public var options: NSOrderedSet?
 
@@ -32,9 +31,10 @@ extension Field {
             return []
         }
         
-        return options.sorted { o1, o2 in
-            return o2.order > o1.order
-        }
+//        return options.sorted { o1, o2 in
+//            return o2 > o1.order
+//        }
+        return options
     }
     
     public var wrappedName: String {

--- a/GitSetKit/GitSetKit.xcdatamodeld/GitSetKit.xcdatamodel/contents
+++ b/GitSetKit/GitSetKit.xcdatamodeld/GitSetKit.xcdatamodel/contents
@@ -2,14 +2,12 @@
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22F82" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Field" representedClassName="Field" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String"/>
-        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="type" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="typeBasedString" optional="YES" attributeType="String"/>
         <relationship name="options" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Option"/>
     </entity>
     <entity name="Option" representedClassName="Option" syncable="YES">
         <attribute name="detailDesc" optional="YES" attributeType="String"/>
-        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="shortDesc" optional="YES" attributeType="String"/>
         <attribute name="value" optional="YES" attributeType="String"/>
     </entity>

--- a/GitSetKit/Option+CoreDataProperties.swift
+++ b/GitSetKit/Option+CoreDataProperties.swift
@@ -19,7 +19,6 @@ extension Option {
     @NSManaged public var value: String?
     @NSManaged public var shortDesc: String?
     @NSManaged public var detailDesc: String?
-    @NSManaged public var order: Int16
 
 }
 

--- a/GitSetKit/Tool/DefaultDataGenerator.swift
+++ b/GitSetKit/Tool/DefaultDataGenerator.swift
@@ -44,7 +44,7 @@ class DefaultDataGenerator {
         let field = Field(context: viewContext)
         field.name = "default_field_type_name".localized
         field.type = Field.FieldType.option.rawValue
-        field.order = 0
+//        field.order = 0
         field.options = NSOrderedSet(array: typeOptions)
         
         return field
@@ -104,7 +104,7 @@ class DefaultDataGenerator {
         let field = Field(context: viewContext)
         field.name = ": "
         field.type = Field.FieldType.constant.rawValue
-        field.order = 2
+//        field.order = 2
         field.typeBasedString = ": "
         
         return field
@@ -115,7 +115,7 @@ class DefaultDataGenerator {
         let field = Field(context: viewContext)
         field.name = "default_field_edit_name".localized
         field.type = Field.FieldType.input.rawValue
-        field.order = 2
+//        field.order = 2
         field.typeBasedString = "default_field_edit_placeholder".localized
         
         return field

--- a/GitSetKit/Window/BlockSettings/OptionBlockSettingView.swift
+++ b/GitSetKit/Window/BlockSettings/OptionBlockSettingView.swift
@@ -8,60 +8,116 @@
 import SwiftUI
 
 struct OptionBlockSettingView: View {
+    @Binding var field: Field?
+    @State private var optionList: [Option] = []
+    @State private var value: [String] = [""]
+    @State private var shortDesc: [String] = [""]
+    @State private var detailDesc: [String] = [""]
+    @State private var isHover: [Bool] = [false]
+    
     var body: some View {
         ScrollView(.vertical) {
-            // MARK: d
-            ForEach(0..<optionCount, id: \.self) { idx in
+            inputField(idx: 0)
+            Spacer()
+            Spacer()
+            ForEach(1..<optionList.count + 1, id: \.self) { idx in
                 inputField(idx: idx)
             }
         }
+        .scrollIndicators(.hidden)
         .shadow(radius: 1)
         .padding()
         .background(
             RoundedRectangle(cornerRadius: 4)
                 .fill(Colors.Gray.quaternary)
         )
+        .onAppear {
+            if let options = field?.wrappedOptions {
+                optionList = options
+                
+                for idx in 0..<optionList.count {
+                    value.append(optionList[idx].value ?? "")
+                    shortDesc.append(optionList[idx].shortDesc ?? "")
+                    detailDesc.append(optionList[idx].detailDesc ?? "")
+                    isHover.append(false)
+                }
+            }
+        }
     }
-    @State private var optionCount = 1
-    
-    @State private var value: String = ""
-    @State private var short: String = ""
-    @State private var detail: String = ""
     
     func inputField(idx: Int) -> some View {
         return HStack {
             Group {
-                TextField("", text: $value, prompt: Text("option_block_field_value"))
+                TextField("", text: $value[idx], prompt: Text("option_block_field_value"))
                     .textFieldStyle(.plain)
                     .multilineTextAlignment(.center)
+                    .onChange(of: value[idx]) { newValue in
+                        if idx != 0 {
+                            optionList[idx - 1].value = newValue
+                            PersistenceController.shared.updateField(field: field!, options: optionList)
+                        }
+                    }
                 Divider()
-                TextField("", text: $short, prompt: Text("option_block_field_short"))
+                TextField("", text: $shortDesc[idx], prompt: Text("option_block_field_short"))
                     .textFieldStyle(.plain)
                     .multilineTextAlignment(.center)
+                    .onChange(of: shortDesc[idx]) { newValue in
+                        if idx != 0 {
+                            optionList[idx - 1].shortDesc = newValue
+                            PersistenceController.shared.updateField(field: field!, options: optionList)
+                        }
+                    }
                 Divider()
-                TextField("", text: $detail, prompt: Text("option_block_field_detail"))
+                TextField("", text: $detailDesc[idx], prompt: Text("option_block_field_detail"))
                     .textFieldStyle(.plain)
                     .multilineTextAlignment(.center)
+                    .onChange(of: detailDesc[idx]) { newValue in
+                        if idx != 0 {
+                            optionList[idx - 1].detailDesc = newValue
+                            PersistenceController.shared.updateField(field: field!, options: optionList)
+                        }
+                    }
             }
+            
             
             if idx == 0 {
                 Button {
-                    optionCount += 1
+                    createOption(idx)
                 } label: {
                     Image(systemName: "plus")
-                        .foregroundColor(Colors.Text.primary)
+                        .foregroundColor(.white)
                 }
                 .buttonStyle(.plain)
                 .frame(width: 24, height: 24)
                 .background(
                     RoundedRectangle(cornerRadius: 8)
                         .fill(Color.accentColor)
+                        .onTapGesture {
+                            createOption(idx)
+                        }
                 )
             }
             else {
-                Rectangle()
-                    .fill(.clear)
-                    .frame(width: 24, height: 24)
+                Button {
+                    deleteOption(idx)
+                } label: {
+                    Image(systemName: "minus")
+                        .foregroundColor(isHover[idx] ? .white : .red)
+                }
+                .buttonStyle(.plain)
+                .frame(width: 24, height: 24)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isHover[idx] ? .red : Colors.Gray.quaternary)
+                        .onTapGesture {
+                            deleteOption(idx)
+                        }
+                )
+                .onHover { newHover in
+                    if idx != optionList.count + 1 {
+                        isHover[idx] = newHover
+                    }
+                }
             }
         }
         .padding(4)
@@ -69,5 +125,32 @@ struct OptionBlockSettingView: View {
             RoundedRectangle(cornerRadius: 8)
                 .fill(Color.white)
         )
+    }
+    
+    func createOption(_ idx: Int) {
+        let count = optionList.count
+        let newOption = PersistenceController.shared.createOption(value: value[0], shortDesc: shortDesc[0], detailDesc: detailDesc[0])
+        
+        optionList.append(newOption)
+        
+        value.append(optionList[count].value ?? "")
+        shortDesc.append(optionList[count].shortDesc ?? "")
+        detailDesc.append(optionList[count].detailDesc ?? "")
+        isHover.append(false)
+        
+        PersistenceController.shared.updateField(field: field!, options: optionList)
+    }
+    
+    func deleteOption(_ idx: Int) {
+        DispatchQueue.main.async {
+            optionList.remove(at: idx - 1)
+            
+            value.remove(at: idx)
+            shortDesc.remove(at: idx)
+            detailDesc.remove(at: idx)
+            isHover.remove(at: idx)
+            
+            PersistenceController.shared.updateField(field: field!, options: optionList)
+        }
     }
 }

--- a/GitSetKit/Window/TemplateView.swift
+++ b/GitSetKit/Window/TemplateView.swift
@@ -91,7 +91,7 @@ struct TemplateView: View {
                             let field = Field(context: managedObjectContext)
                             field.name = "block_new_field_name".localized
                             field.type = Field.FieldType.constant.rawValue
-                            field.order = 0
+//                            field.order = 0
                             field.typeBasedString = ""
                             
                             var fields = self.team!.wrappedFields


### PR DESCRIPTION
1. 옵션 블럭에 대한 설정 뷰에 Core Data를 연동했습니다.
2. Datamodel 및 Core Data 클래스에서 배열로 입력받는 필드는 NSOrderedSet으로 order 필드의 유효성이 없어 관련 코드를 삭제했습니다.