### PR TITLE
feat: InputBlockSettingView에 대한 Core Data 연동

### DIFF
--- a/GitSetKit/Window/BlockSettings/InputBlockSettingView.swift
+++ b/GitSetKit/Window/BlockSettings/InputBlockSettingView.swift
@@ -8,6 +8,11 @@
 import SwiftUI
 
 struct InputBlockSettingView: View {
+    @Binding var field: Field?
+    @State var value: String = "input_block_field_placeholder".localized
+    @State var typeBasedString: String?
+    @State var bindedField: Field?
+    
     var body: some View {
         VStack(alignment: .leading) {
             Text("input_block_field_text")
@@ -31,13 +36,13 @@ struct InputBlockSettingView: View {
             RoundedRectangle(cornerRadius: 4)
                 .fill(Colors.Gray.quaternary)
         )
-    }
-    
-    @State private var value: String = "input_block_field_placeholder".localized
-}
-
-struct InputBlockSettingView_Previews: PreviewProvider {
-    static var previews: some View {
-        InputBlockSettingView()
+        .onAppear {
+            bindedField = field
+            guard let string = bindedField?.wrappedTypeBasedString else { return }
+            value = string
+        }
+        .onDisappear {
+            PersistenceController.shared.updateField(field: bindedField!, typeBasedString: value)
+        }
     }
 }


### PR DESCRIPTION
1. 입력 블럭에서 onAppear와 onDisappear를 통해 Core Data를 관리하도록 추가 했습니다.
2. bindedField 변수를 통해 뷰가 disappear 되더라도 binding된 변수가 unbinding 되지 않도록 했습니다.